### PR TITLE
Ftrace binder

### DIFF
--- a/ftrace/parsers/__init__.py
+++ b/ftrace/parsers/__init__.py
@@ -116,3 +116,4 @@ from .binder_transaction_alloc_buf import binder_transaction_alloc_buf
 from .binder_write_done import binder_write_done
 from .binder_read_done import binder_read_done
 from .binder_ioctl_done import binder_ioctl_done
+from .binder_transaction_received import binder_transaction_received

--- a/ftrace/parsers/__init__.py
+++ b/ftrace/parsers/__init__.py
@@ -102,3 +102,5 @@ from .sched_boost_cpu import sched_boost_cpu
 from .sched_contrib_scale_f import sched_contrib_scale_f
 from .sched_load_avg_task import sched_load_avg_task
 from .sched_load_avg_cpu import sched_load_avg_cpu
+# Android binder
+from .binder_ioctl import binder_ioctl

--- a/ftrace/parsers/__init__.py
+++ b/ftrace/parsers/__init__.py
@@ -111,3 +111,4 @@ from .binder_locked import binder_locked
 from .binder_command import binder_command
 from .binder_wait_for_work import binder_wait_for_work
 from .binder_transaction_buffer_release import binder_transaction_buffer_release
+from .binder_transaction import binder_transaction

--- a/ftrace/parsers/__init__.py
+++ b/ftrace/parsers/__init__.py
@@ -108,3 +108,4 @@ from .binder_return import binder_return
 from .binder_lock import binder_lock
 from .binder_unlock import binder_unlock
 from .binder_locked import binder_locked
+from .binder_command import binder_command

--- a/ftrace/parsers/__init__.py
+++ b/ftrace/parsers/__init__.py
@@ -121,3 +121,4 @@ from .binder_transaction_ref_to_node import binder_transaction_ref_to_node
 from .binder_transaction_node_to_ref import binder_transaction_node_to_ref
 from .binder_transaction_fd import binder_transaction_fd
 from .binder_transaction_ref_to_ref import binder_transaction_ref_to_ref
+from .binder_update_page_range import binder_update_page_range

--- a/ftrace/parsers/__init__.py
+++ b/ftrace/parsers/__init__.py
@@ -104,3 +104,4 @@ from .sched_load_avg_task import sched_load_avg_task
 from .sched_load_avg_cpu import sched_load_avg_cpu
 # Android binder
 from .binder_ioctl import binder_ioctl
+from .binder_return import binder_return

--- a/ftrace/parsers/__init__.py
+++ b/ftrace/parsers/__init__.py
@@ -117,3 +117,5 @@ from .binder_write_done import binder_write_done
 from .binder_read_done import binder_read_done
 from .binder_ioctl_done import binder_ioctl_done
 from .binder_transaction_received import binder_transaction_received
+from .binder_transaction_ref_to_node import binder_transaction_ref_to_node
+from .binder_transaction_node_to_ref import binder_transaction_node_to_ref

--- a/ftrace/parsers/__init__.py
+++ b/ftrace/parsers/__init__.py
@@ -120,3 +120,4 @@ from .binder_transaction_received import binder_transaction_received
 from .binder_transaction_ref_to_node import binder_transaction_ref_to_node
 from .binder_transaction_node_to_ref import binder_transaction_node_to_ref
 from .binder_transaction_fd import binder_transaction_fd
+from .binder_transaction_ref_to_ref import binder_transaction_ref_to_ref

--- a/ftrace/parsers/__init__.py
+++ b/ftrace/parsers/__init__.py
@@ -119,3 +119,4 @@ from .binder_ioctl_done import binder_ioctl_done
 from .binder_transaction_received import binder_transaction_received
 from .binder_transaction_ref_to_node import binder_transaction_ref_to_node
 from .binder_transaction_node_to_ref import binder_transaction_node_to_ref
+from .binder_transaction_fd import binder_transaction_fd

--- a/ftrace/parsers/__init__.py
+++ b/ftrace/parsers/__init__.py
@@ -105,3 +105,6 @@ from .sched_load_avg_cpu import sched_load_avg_cpu
 # Android binder
 from .binder_ioctl import binder_ioctl
 from .binder_return import binder_return
+from .binder_lock import binder_lock
+from .binder_unlock import binder_unlock
+from .binder_locked import binder_locked

--- a/ftrace/parsers/__init__.py
+++ b/ftrace/parsers/__init__.py
@@ -113,3 +113,4 @@ from .binder_wait_for_work import binder_wait_for_work
 from .binder_transaction_buffer_release import binder_transaction_buffer_release
 from .binder_transaction import binder_transaction
 from .binder_transaction_alloc_buf import binder_transaction_alloc_buf
+from .binder_write_done import binder_write_done

--- a/ftrace/parsers/__init__.py
+++ b/ftrace/parsers/__init__.py
@@ -112,3 +112,4 @@ from .binder_command import binder_command
 from .binder_wait_for_work import binder_wait_for_work
 from .binder_transaction_buffer_release import binder_transaction_buffer_release
 from .binder_transaction import binder_transaction
+from .binder_transaction_alloc_buf import binder_transaction_alloc_buf

--- a/ftrace/parsers/__init__.py
+++ b/ftrace/parsers/__init__.py
@@ -114,3 +114,5 @@ from .binder_transaction_buffer_release import binder_transaction_buffer_release
 from .binder_transaction import binder_transaction
 from .binder_transaction_alloc_buf import binder_transaction_alloc_buf
 from .binder_write_done import binder_write_done
+from .binder_read_done import binder_read_done
+from .binder_ioctl_done import binder_ioctl_done

--- a/ftrace/parsers/__init__.py
+++ b/ftrace/parsers/__init__.py
@@ -110,3 +110,4 @@ from .binder_unlock import binder_unlock
 from .binder_locked import binder_locked
 from .binder_command import binder_command
 from .binder_wait_for_work import binder_wait_for_work
+from .binder_transaction_buffer_release import binder_transaction_buffer_release

--- a/ftrace/parsers/__init__.py
+++ b/ftrace/parsers/__init__.py
@@ -109,3 +109,4 @@ from .binder_lock import binder_lock
 from .binder_unlock import binder_unlock
 from .binder_locked import binder_locked
 from .binder_command import binder_command
+from .binder_wait_for_work import binder_wait_for_work

--- a/ftrace/parsers/binder.py
+++ b/ftrace/parsers/binder.py
@@ -1,0 +1,135 @@
+# see Documentation/ioctl/ioctl-decoding.txt for decoding ioctls()
+param_types = {
+    0: 'no params',
+    1: 'read',
+    2: 'write',
+    3: 'read-write'
+}
+
+def binder_ioctl (fun):
+
+    # From include/uapi/linux/android/binder.h
+    if fun == 1:
+        return "READ_WRITE"
+    elif fun == 3:
+        return "SET_IDLE_TIMEOUT"
+    elif fun == 5:
+        return "SET_MAX_THREADS"
+    elif fun == 6:
+        return "SET_IDLE_PRIORITY"
+    elif fun == 7:
+        return "SET_CONTEXT_MGR"
+    elif fun == 8:
+        return "THREAD_EXIT"
+    elif fun == 9:
+        return "VERSION"
+    elif fun == 11:
+        return "GET_NODE_DEBUG_INFO"
+    else:
+        return "INVALID_BINDER_IOCTL:%d" % (int(fun))
+
+def binder_command (fun):
+
+    # From include/uapi/linux/android/binder.h
+    if fun == 0:
+        return "TRANSACTION"
+    elif fun == 1:
+        return "REPLY"
+    elif fun == 2:
+        return "ACQUIRE_RESULT"
+    elif fun == 3:
+        return "FREE_BUFFER"
+    elif fun == 4:
+        return "INCREFS"
+    elif fun == 5:
+        return "ACQUIRE"
+    elif fun == 6:
+        return "RELEASE"
+    elif fun == 7:
+        return "DECREFS"
+    elif fun == 8:
+        return "INCREFS_DONE"
+    elif fun == 9:
+        return "ACQUIRE_DONE"
+    elif fun == 10:
+        return "ATTEMPT_ACQUIRE"
+    elif fun == 11:
+        return "REGISTER_LOOPER"
+    elif fun == 12:
+        return "ENTER_LOOPER"
+    elif fun == 13:
+        return "EXIT_LOOPER"
+    elif fun == 14:
+        return "REQUEST_DEATH_NOTIFICATION"
+    elif fun == 15:
+        return "CLEAR_DEATH_NOTIFICATION"
+    elif fun == 16:
+        return "DEAD_BINDER_DONE"
+    elif fun == 17:
+        return "TRANSACTION_SG"
+    elif fun == 18:
+        return "REPLY_SG"
+    else:
+        return "INVALID_BINDER_COMMAND:%d" % (int(fun))
+
+def binder_return (fun):
+
+    # From include/uapi/linux/android/binder.h
+    if fun == 0:
+        return "ERROR"
+    elif fun == 1:
+        return "OK"
+    elif fun == 2:
+        return "TRANSACTION"
+    elif fun == 3:
+        return "REPLY"
+    elif fun == 4:
+        return "ACQUIRE_RESULT"
+    elif fun == 5:
+        return "DEAD_REPLY"
+    elif fun == 6:
+        return "TRANSACTION_COMPLETE"
+    elif fun == 7:
+        return "INCREFS"
+    elif fun == 8:
+        return "ACQUIRE"
+    elif fun == 9:
+        return "RELEASE"
+    elif fun == 10:
+        return "DECREFS"
+    elif fun == 11:
+        return "ATTEMPT_ACQUIRE"
+    elif fun == 12:
+        return "NOOP"
+    elif fun == 13:
+        return "SPAWN_LOOPER"
+    elif fun == 14:
+        return "FINISHED"
+    elif fun == 15:
+        return "DEAD_BINDER"
+    elif fun == 16:
+        return "CLEAR_DEATH_NOTIFICATION_DONE"
+    elif fun == 17:
+        return "FAILED_REPLY"
+    else:
+        return "INVALID_BINDER_RETURN:%d" % (int(fun))
+
+def parse_binder_cmd (cmd):
+
+    cmd_type = (cmd & 0xc0000000) >> 30
+    cmd_size = (cmd & 0x3fff0000) >> 16
+    cmd_id   = (cmd & 0x0000ff00) >>  8
+    cmd_fun  = (cmd & 0x000000ff) >>  0
+
+    cmd_type = param_types[cmd_type]
+
+    if chr(cmd_id) == 'b':
+        return (binder_ioctl (cmd_fun), cmd_type)
+
+    if chr(cmd_id) == 'c':
+        return (binder_command (cmd_fun), cmd_type)
+
+    if chr(cmd_id) == 'r':
+        return (binder_return (cmd_fun), cmd_type)
+
+    return ("INV_ID:%c[size=%d,fun=%d]" % (cmd_id, cmd_size, cmd_fun), cmd_type)

--- a/ftrace/parsers/binder_command.py
+++ b/ftrace/parsers/binder_command.py
@@ -35,7 +35,7 @@ class BinderCommand(BinderCommandBase):
                 result=result
             )
 
-binder_ioctl_pattern = re.compile(
+binder_command_pattern = re.compile(
     r"""
     cmd=(0x[0-9a-f]+)\s+
     BC_([A-Z_]+)
@@ -47,7 +47,7 @@ binder_ioctl_pattern = re.compile(
 def binder_command(payload):
     """Parser for `binder_command`"""
     try:
-        match = re.match(binder_ioctl_pattern, payload)
+        match = re.match(binder_command_pattern, payload)
         if match:
             match_group_dict = match.groupdict()
             return BinderCommand(match.group(1), match.group(2))

--- a/ftrace/parsers/binder_command.py
+++ b/ftrace/parsers/binder_command.py
@@ -51,5 +51,5 @@ def binder_command(payload):
         if match:
             match_group_dict = match.groupdict()
             return BinderCommand(match.group(1), match.group(2))
-    except Exception, e:
+    except Exception as e:
         raise ParserError(e.message)

--- a/ftrace/parsers/binder_command.py
+++ b/ftrace/parsers/binder_command.py
@@ -1,0 +1,55 @@
+import re
+from ftrace.common import ParserError
+from .register import register_parser
+from .binder import parse_binder_cmd
+from collections import namedtuple
+
+TRACEPOINT = 'binder_command'
+
+__all__ = [TRACEPOINT]
+
+#binder_command: cmd=0x40046303 BC_FREE_BUFFER
+
+BinderCommandBase = namedtuple(TRACEPOINT,
+    [
+    'cmd',
+    'mode',
+    'result'
+    ]
+)
+
+class BinderCommand(BinderCommandBase):
+    __slots__ = ()
+    def __new__(cls, cmd, result):
+
+            (cmd, mode) = parse_binder_cmd (int (cmd, base=16))
+
+            # Decoded command and text output must be consistent
+            if cmd != result:
+                return "Invalid command (%s != %s)" % (cmd, result)
+
+            return super(cls, BinderCommand).__new__(
+                cls,
+                cmd=cmd,
+                mode=mode,
+                result=result
+            )
+
+binder_ioctl_pattern = re.compile(
+    r"""
+    cmd=(0x[0-9a-f]+)\s+
+    BC_([A-Z_]+)
+    """,
+    re.X|re.M
+)
+
+@register_parser
+def binder_command(payload):
+    """Parser for `binder_command`"""
+    try:
+        match = re.match(binder_ioctl_pattern, payload)
+        if match:
+            match_group_dict = match.groupdict()
+            return BinderCommand(match.group(1), match.group(2))
+    except Exception, e:
+        raise ParserError(e.message)

--- a/ftrace/parsers/binder_ioctl.py
+++ b/ftrace/parsers/binder_ioctl.py
@@ -1,0 +1,48 @@
+import re
+from ftrace.common import ParserError
+from .register import register_parser
+from collections import namedtuple
+
+TRACEPOINT = 'binder_ioctl'
+
+__all__ = [TRACEPOINT]
+
+#binder_ioctl: cmd=0xc0186201 arg=0xbea7dc28
+
+BinderIoctlBase = namedtuple(TRACEPOINT,
+    [
+    'cmd',
+    'arg',
+    ]
+)
+
+class BinderIoctl(BinderIoctlBase):
+    __slots__ = ()
+    def __new__(cls, cmd, arg):
+            cmd = int(cmd, base=16)
+            arg = int(arg, base=16)
+
+            return super(cls, BinderIoctl).__new__(
+                cls,
+                cmd=cmd,
+                arg=arg,
+            )
+
+binder_ioctl_pattern = re.compile(
+    r"""
+    cmd=(0x[0-9a-f]+)\s+
+    arg=(0x[0-9a-f]+)
+    """,
+    re.X|re.M
+)
+
+@register_parser
+def binder_ioctl(payload):
+    """Parser for `binder_ioctl`"""
+    try:
+        match = re.match(binder_ioctl_pattern, payload)
+        if match:
+            match_group_dict = match.groupdict()
+            return BinderIoctl(match.group(1), match.group(2))
+    except Exception, e:
+        raise ParserError(e.message)

--- a/ftrace/parsers/binder_ioctl.py
+++ b/ftrace/parsers/binder_ioctl.py
@@ -48,5 +48,5 @@ def binder_ioctl(payload):
         if match:
             match_group_dict = match.groupdict()
             return BinderIoctl(match.group(1), match.group(2))
-    except Exception, e:
+    except Exception as e:
         raise ParserError(e.message)

--- a/ftrace/parsers/binder_ioctl.py
+++ b/ftrace/parsers/binder_ioctl.py
@@ -13,6 +13,7 @@ __all__ = [TRACEPOINT]
 BinderIoctlBase = namedtuple(TRACEPOINT,
     [
     'cmd',
+    'mode',
     'arg',
     ]
 )
@@ -21,12 +22,13 @@ class BinderIoctl(BinderIoctlBase):
     __slots__ = ()
     def __new__(cls, cmd, arg):
 
-            cmd = parse_binder_cmd (int(cmd, base=16))
+            (cmd, mode) = parse_binder_cmd (int(cmd, base=16))
             arg = int(arg, base=16)
 
             return super(cls, BinderIoctl).__new__(
                 cls,
                 cmd=cmd,
+                mode=mode,
                 arg=hex(arg),
             )
 

--- a/ftrace/parsers/binder_ioctl_done.py
+++ b/ftrace/parsers/binder_ioctl_done.py
@@ -1,0 +1,44 @@
+import re
+from ftrace.common import ParserError
+from .register import register_parser
+from .binder import parse_binder_cmd
+from collections import namedtuple
+
+TRACEPOINT = 'binder_ioctl_done'
+
+__all__ = [TRACEPOINT]
+
+#binder_ioctl_done: ret=0
+
+BinderIoctlDoneBase = namedtuple(TRACEPOINT,
+    [
+    'ret'
+    ]
+)
+
+class BinderIoctlDone(BinderIoctlDoneBase):
+    __slots__ = ()
+    def __new__(cls, ret):
+
+            return super(cls, BinderIoctlDone).__new__(
+                cls,
+                ret=ret
+            )
+
+binder_ioctl_done_pattern = re.compile(
+    r"""
+    ret=(\d+)
+    """,
+    re.X|re.M
+)
+
+@register_parser
+def binder_ioctl_done(payload):
+    """Parser for `binder_ioctl_done`"""
+    try:
+        match = re.match(binder_ioctl_done_pattern, payload)
+        if match:
+            match_group_dict = match.groupdict()
+            return BinderIoctlDone(int(match.group(1)))
+    except Exception as e:
+        raise ParserError(e.message)

--- a/ftrace/parsers/binder_lock.py
+++ b/ftrace/parsers/binder_lock.py
@@ -1,0 +1,43 @@
+import re
+from ftrace.common import ParserError
+from .register import register_parser
+from collections import namedtuple
+
+TRACEPOINT = 'binder_lock'
+
+__all__ = [TRACEPOINT]
+
+#binder_lock: tag=binder_ioctl
+
+BinderLockBase = namedtuple(TRACEPOINT,
+    [
+    'tag'
+    ]
+)
+
+class BinderLock(BinderLockBase):
+    __slots__ = ()
+    def __new__(cls, tag):
+            return super(cls, BinderLock).__new__(
+                cls,
+                tag=tag
+            )
+
+binder_lock_pattern = re.compile(
+    r"""
+    tag=([^\s]+)
+    """,
+    re.X|re.M
+)
+
+@register_parser
+def binder_lock(payload):
+    """Parser for `binder_lock`"""
+    try:
+        match = re.match(binder_lock_pattern, payload)
+        if match:
+            match_group_dict = match.groupdict()
+            return BinderLock(match.group(1))
+    except Exception, e:
+        raise ParserError(e.message)
+

--- a/ftrace/parsers/binder_lock.py
+++ b/ftrace/parsers/binder_lock.py
@@ -38,6 +38,6 @@ def binder_lock(payload):
         if match:
             match_group_dict = match.groupdict()
             return BinderLock(match.group(1))
-    except Exception, e:
+    except Exception as e:
         raise ParserError(e.message)
 

--- a/ftrace/parsers/binder_locked.py
+++ b/ftrace/parsers/binder_locked.py
@@ -1,0 +1,43 @@
+import re
+from ftrace.common import ParserError
+from .register import register_parser
+from collections import namedtuple
+
+TRACEPOINT = 'binder_locked'
+
+__all__ = [TRACEPOINT]
+
+#binder_locked: tag=binder_ioctl
+
+BinderLockedBase = namedtuple(TRACEPOINT,
+    [
+    'tag'
+    ]
+)
+
+class BinderLocked(BinderLockedBase):
+    __slots__ = ()
+    def __new__(cls, tag):
+            return super(cls, BinderLocked).__new__(
+                cls,
+                tag=tag
+            )
+
+binder_locked_pattern = re.compile(
+    r"""
+    tag=([^\s]+)
+    """,
+    re.X|re.M
+)
+
+@register_parser
+def binder_locked(payload):
+    """Parser for `binder_locked`"""
+    try:
+        match = re.match(binder_locked_pattern, payload)
+        if match:
+            match_group_dict = match.groupdict()
+            return BinderLocked(match.group(1))
+    except Exception, e:
+        raise ParserError(e.message)
+

--- a/ftrace/parsers/binder_locked.py
+++ b/ftrace/parsers/binder_locked.py
@@ -38,6 +38,6 @@ def binder_locked(payload):
         if match:
             match_group_dict = match.groupdict()
             return BinderLocked(match.group(1))
-    except Exception, e:
+    except Exception as e:
         raise ParserError(e.message)
 

--- a/ftrace/parsers/binder_read_done.py
+++ b/ftrace/parsers/binder_read_done.py
@@ -1,0 +1,44 @@
+import re
+from ftrace.common import ParserError
+from .register import register_parser
+from .binder import parse_binder_cmd
+from collections import namedtuple
+
+TRACEPOINT = 'binder_read_done'
+
+__all__ = [TRACEPOINT]
+
+#binder_read_done: ret=0
+
+BinderReadDoneBase = namedtuple(TRACEPOINT,
+    [
+    'ret'
+    ]
+)
+
+class BinderReadDone(BinderReadDoneBase):
+    __slots__ = ()
+    def __new__(cls, ret):
+
+            return super(cls, BinderReadDone).__new__(
+                cls,
+                ret=ret
+            )
+
+binder_read_done_pattern = re.compile(
+    r"""
+    ret=(\d+)
+    """,
+    re.X|re.M
+)
+
+@register_parser
+def binder_read_done(payload):
+    """Parser for `binder_read_done`"""
+    try:
+        match = re.match(binder_read_done_pattern, payload)
+        if match:
+            match_group_dict = match.groupdict()
+            return BinderReadDone(int(match.group(1)))
+    except Exception as e:
+        raise ParserError(e.message)

--- a/ftrace/parsers/binder_return.py
+++ b/ftrace/parsers/binder_return.py
@@ -47,5 +47,5 @@ def binder_return(payload):
         if match:
             match_group_dict = match.groupdict()
             return BinderReturn(match.group(1), match.group(2))
-    except Exception, e:
+    except Exception as e:
         raise ParserError(e.message)

--- a/ftrace/parsers/binder_return.py
+++ b/ftrace/parsers/binder_return.py
@@ -13,20 +13,22 @@ __all__ = [TRACEPOINT]
 BinderReturnBase = namedtuple(TRACEPOINT,
     [
     'cmd',
-    'rv',
+    'mode',
+    'result',
     ]
 )
 
 class BinderReturn(BinderReturnBase):
     __slots__ = ()
-    def __new__(cls, cmd, rv):
+    def __new__(cls, cmd, result):
 
-            cmd = parse_binder_cmd (int (cmd, base=16))
+            (cmd, mode) = parse_binder_cmd (int (cmd, base=16))
 
             return super(cls, BinderReturn).__new__(
                 cls,
                 cmd=cmd,
-                rv=rv
+                mode=mode,
+                result=result
             )
 
 binder_ioctl_pattern = re.compile(

--- a/ftrace/parsers/binder_return.py
+++ b/ftrace/parsers/binder_return.py
@@ -31,7 +31,7 @@ class BinderReturn(BinderReturnBase):
                 result=result
             )
 
-binder_ioctl_pattern = re.compile(
+binder_return_pattern = re.compile(
     r"""
     cmd=(0x[0-9a-f]+)\s+
     BR_([A-Z]+)
@@ -43,7 +43,7 @@ binder_ioctl_pattern = re.compile(
 def binder_return(payload):
     """Parser for `binder_return`"""
     try:
-        match = re.match(binder_ioctl_pattern, payload)
+        match = re.match(binder_return_pattern, payload)
         if match:
             match_group_dict = match.groupdict()
             return BinderReturn(match.group(1), match.group(2))

--- a/ftrace/parsers/binder_transaction.py
+++ b/ftrace/parsers/binder_transaction.py
@@ -1,0 +1,91 @@
+import re
+from ftrace.common import ParserError
+from .register import register_parser
+from .binder import parse_binder_cmd
+from collections import namedtuple
+
+TRACEPOINT = 'binder_transaction'
+
+__all__ = [TRACEPOINT]
+
+#binder_transaction: transaction=135931 dest_node=133235 dest_proc=280 dest_thread=0 reply=0 flags=0x10 code=0x2
+
+BinderTransactionBase = namedtuple(TRACEPOINT,
+    [
+    'transaction',
+    'dest_node',
+    'dest_proc',
+    'dest_thread',
+    'reply',
+    'flags',
+    'code'
+    ]
+)
+
+def decode_transaction_flags (flags):
+
+    result = set()
+
+    # this is a one-way call: async, no return
+    if flags & 0x01: result.add ('TF_ONE_WAY')
+
+    # contents are the component's root object
+    if flags & 0x04: result.add ('TF_ROOT_OBJECT')
+
+    # contents are a 32-bit status code
+    if flags & 0x08: result.add ('TF_STATUS_CODE')
+
+    # allow replies with file descriptors
+    if flags & 0x10: result.add ('TF_ACCEPT_FDS')
+
+    # Check for missing flags
+    remain = flags & 0xffffffe2
+    if remain: result.add ('UNKNOWN_FLAGS_%x' % remain)
+
+    return result
+
+
+class BinderTransaction(BinderTransactionBase):
+    __slots__ = ()
+    def __new__(cls, transaction, dest_node, dest_proc, dest_thread, reply, flags, code):
+
+            return super(cls, BinderTransaction).__new__(
+                cls,
+                transaction=transaction,
+                dest_node=dest_node,
+                dest_proc=dest_proc,
+                dest_thread=dest_thread,
+                reply=reply,
+                flags=flags,
+                code=code
+            )
+
+binder_ioctl_pattern = re.compile(
+    r"""
+    transaction=(\d+)\s+
+    dest_node=(\d+)\s+
+    dest_proc=(\d+)\s+
+    dest_thread=(\d+)\s+
+    reply=(\d+)\s+
+    flags=(0x[0-9a-f]+)\s+
+    code=(0x[0-9a-f]+)
+    """,
+    re.X|re.M
+)
+
+@register_parser
+def binder_transaction(payload):
+    """Parser for `binder_transaction`"""
+    try:
+        match = re.match(binder_ioctl_pattern, payload)
+        if match:
+            match_group_dict = match.groupdict()
+            return BinderTransaction(int(match.group(1)),
+                                     int(match.group(2)),
+                                     int(match.group(3)),
+                                     int(match.group(4)),
+                                     int(match.group(5)),
+                                     decode_transaction_flags (int(match.group(6), base=16)),
+                                     int(match.group(7), base=16))
+    except Exception as e:
+        raise ParserError(e.message)

--- a/ftrace/parsers/binder_transaction.py
+++ b/ftrace/parsers/binder_transaction.py
@@ -60,7 +60,7 @@ class BinderTransaction(BinderTransactionBase):
                 code=code
             )
 
-binder_ioctl_pattern = re.compile(
+binder_transaction_pattern = re.compile(
     r"""
     transaction=(\d+)\s+
     dest_node=(\d+)\s+
@@ -77,7 +77,7 @@ binder_ioctl_pattern = re.compile(
 def binder_transaction(payload):
     """Parser for `binder_transaction`"""
     try:
-        match = re.match(binder_ioctl_pattern, payload)
+        match = re.match(binder_transaction_pattern, payload)
         if match:
             match_group_dict = match.groupdict()
             return BinderTransaction(int(match.group(1)),

--- a/ftrace/parsers/binder_transaction_alloc_buf.py
+++ b/ftrace/parsers/binder_transaction_alloc_buf.py
@@ -29,7 +29,7 @@ class BinderTransactionAllocBuf(BinderTransactionAllocBufBase):
                 offsets_size=offsets_size
             )
 
-binder_ioctl_pattern = re.compile(
+binder_transaction_alloc_buf_pattern = re.compile(
     r"""
     transaction=(\d+)\s+
     data_size=(\d+)\s+
@@ -42,7 +42,7 @@ binder_ioctl_pattern = re.compile(
 def binder_transaction_alloc_buf(payload):
     """Parser for `binder_transaction_alloc_buf`"""
     try:
-        match = re.match(binder_ioctl_pattern, payload)
+        match = re.match(binder_transaction_alloc_buf_pattern, payload)
         if match:
             match_group_dict = match.groupdict()
             return BinderTransactionAllocBuf(int(match.group(1)), int(match.group(2)), int(match.group(3)))

--- a/ftrace/parsers/binder_transaction_alloc_buf.py
+++ b/ftrace/parsers/binder_transaction_alloc_buf.py
@@ -1,0 +1,50 @@
+import re
+from ftrace.common import ParserError
+from .register import register_parser
+from .binder import parse_binder_cmd
+from collections import namedtuple
+
+TRACEPOINT = 'binder_transaction_alloc_buf'
+
+__all__ = [TRACEPOINT]
+
+#binder_transaction_alloc_buf: transaction=135931 data_size=96 offsets_size=0
+
+BinderTransactionAllocBufBase = namedtuple(TRACEPOINT,
+    [
+    'transaction',
+    'data_size',
+    'offsets_size'
+    ]
+)
+
+class BinderTransactionAllocBuf(BinderTransactionAllocBufBase):
+    __slots__ = ()
+    def __new__(cls, transaction, data_size, offsets_size):
+
+            return super(cls, BinderTransactionAllocBuf).__new__(
+                cls,
+                transaction=transaction,
+                data_size=data_size,
+                offsets_size=offsets_size
+            )
+
+binder_ioctl_pattern = re.compile(
+    r"""
+    transaction=(\d+)\s+
+    data_size=(\d+)\s+
+    offsets_size=(\d+)
+    """,
+    re.X|re.M
+)
+
+@register_parser
+def binder_transaction_alloc_buf(payload):
+    """Parser for `binder_transaction_alloc_buf`"""
+    try:
+        match = re.match(binder_ioctl_pattern, payload)
+        if match:
+            match_group_dict = match.groupdict()
+            return BinderTransactionAllocBuf(int(match.group(1)), int(match.group(2)), int(match.group(3)))
+    except Exception as e:
+        raise ParserError(e.message)

--- a/ftrace/parsers/binder_transaction_buffer_release.py
+++ b/ftrace/parsers/binder_transaction_buffer_release.py
@@ -1,0 +1,50 @@
+import re
+from ftrace.common import ParserError
+from .register import register_parser
+from .binder import parse_binder_cmd
+from collections import namedtuple
+
+TRACEPOINT = 'binder_transaction_buffer_release'
+
+__all__ = [TRACEPOINT]
+
+#binder_transaction_buffer_release: transaction=135918 data_size=28 offsets_size=0
+
+BinderTransactionBufferReleaseBase = namedtuple(TRACEPOINT,
+    [
+    'transaction',
+    'data_size',
+    'offsets_size'
+    ]
+)
+
+class BinderTransactionBufferRelease(BinderTransactionBufferReleaseBase):
+    __slots__ = ()
+    def __new__(cls, transaction, data_size, offsets_size):
+
+            return super(cls, BinderTransactionBufferRelease).__new__(
+                cls,
+                transaction=transaction,
+                data_size=data_size,
+                offsets_size=offsets_size
+            )
+
+binder_ioctl_pattern = re.compile(
+    r"""
+    transaction=(\d+)\s+
+    data_size=(\d+)\s+
+    offsets_size=(\d+)
+    """,
+    re.X|re.M
+)
+
+@register_parser
+def binder_transaction_buffer_release(payload):
+    """Parser for `binder_transaction_buffer_release`"""
+    try:
+        match = re.match(binder_ioctl_pattern, payload)
+        if match:
+            match_group_dict = match.groupdict()
+            return BinderTransactionBufferRelease(int(match.group(1)), int(match.group(2)), int(match.group(3)))
+    except Exception as e:
+        raise ParserError(e.message)

--- a/ftrace/parsers/binder_transaction_buffer_release.py
+++ b/ftrace/parsers/binder_transaction_buffer_release.py
@@ -29,7 +29,7 @@ class BinderTransactionBufferRelease(BinderTransactionBufferReleaseBase):
                 offsets_size=offsets_size
             )
 
-binder_ioctl_pattern = re.compile(
+binder_transaction_buffer_release_pattern = re.compile(
     r"""
     transaction=(\d+)\s+
     data_size=(\d+)\s+
@@ -42,7 +42,7 @@ binder_ioctl_pattern = re.compile(
 def binder_transaction_buffer_release(payload):
     """Parser for `binder_transaction_buffer_release`"""
     try:
-        match = re.match(binder_ioctl_pattern, payload)
+        match = re.match(binder_transaction_buffer_release_pattern, payload)
         if match:
             match_group_dict = match.groupdict()
             return BinderTransactionBufferRelease(int(match.group(1)), int(match.group(2)), int(match.group(3)))

--- a/ftrace/parsers/binder_transaction_fd.py
+++ b/ftrace/parsers/binder_transaction_fd.py
@@ -1,0 +1,53 @@
+import re
+from ftrace.common import ParserError
+from .register import register_parser
+from .binder import parse_binder_cmd
+from collections import namedtuple
+
+TRACEPOINT = 'binder_transaction_fd'
+
+__all__ = [TRACEPOINT]
+
+#binder_transaction_fd: transaction=135945 src_fd=63 ==> dest_fd=30
+
+BinderTransactionFdBase = namedtuple(TRACEPOINT,
+    [
+    'transaction',
+    'src_fd',
+    'dest_fd'
+    ]
+)
+
+class BinderTransactionFd(BinderTransactionFdBase):
+    __slots__ = ()
+    def __new__(cls, transaction, src_fd, dest_fd):
+
+            return super(cls, BinderTransactionFd).__new__(
+                cls,
+                transaction=transaction,
+                src_fd=src_fd,
+                dest_fd=dest_fd
+            )
+
+binder_transaction_fd_pattern = re.compile(
+    r"""
+    transaction=(\d+)\s+
+    src_fd=(\d+)\s+
+    ==>\s+
+    dest_fd=(\d+)
+    """,
+    re.X|re.M
+)
+
+@register_parser
+def binder_transaction_fd(payload):
+    """Parser for `binder_transaction_fd`"""
+    try:
+        match = re.match(binder_transaction_fd_pattern, payload)
+        if match:
+            match_group_dict = match.groupdict()
+            return BinderTransactionFd(int(match.group(1)),
+                                              int(match.group(2)),
+                                              int(match.group(3)))
+    except Exception as e:
+        raise ParserError(e.message)

--- a/ftrace/parsers/binder_transaction_node_to_ref.py
+++ b/ftrace/parsers/binder_transaction_node_to_ref.py
@@ -1,0 +1,61 @@
+import re
+from ftrace.common import ParserError
+from .register import register_parser
+from .binder import parse_binder_cmd
+from collections import namedtuple
+
+TRACEPOINT = 'binder_transaction_node_to_ref'
+
+__all__ = [TRACEPOINT]
+
+#binder_transaction_node_to_ref: transaction=136064 node=135403 src_ptr=0x00000000b2eacc40 ==> dest_ref=135404 dest_desc=525
+
+BinderTransactionNodeToRefBase = namedtuple(TRACEPOINT,
+    [
+    'transaction',
+    'node',
+    'src_ptr',
+    'dest_ref',
+    'dest_desc'
+    ]
+)
+
+class BinderTransactionNodeToRef(BinderTransactionNodeToRefBase):
+    __slots__ = ()
+    def __new__(cls, transaction, node, src_ptr, dest_ref, dest_desc):
+
+            return super(cls, BinderTransactionNodeToRef).__new__(
+                cls,
+                transaction=transaction,
+                node=node,
+                src_ptr=src_ptr,
+                dest_ref=dest_ref,
+                dest_desc=dest_desc
+            )
+
+binder_transaction_node_to_ref_pattern = re.compile(
+    r"""
+    transaction=(\d+)\s+
+    node=(\d+)\s+
+    src_ptr=(0x[0-9a-f]+)\s+
+    ==>\s+
+    dest_ref=(\d+)\s+
+    dest_desc=(\d+)
+    """,
+    re.X|re.M
+)
+
+@register_parser
+def binder_transaction_node_to_ref(payload):
+    """Parser for `binder_transaction_node_to_ref`"""
+    try:
+        match = re.match(binder_transaction_node_to_ref_pattern, payload)
+        if match:
+            match_group_dict = match.groupdict()
+            return BinderTransactionNodeToRef(int(match.group(1)),
+                                              int(match.group(2)),
+                                              int(match.group(3), base=16),
+                                              int(match.group(4)),
+                                              int(match.group(5)))
+    except Exception as e:
+        raise ParserError(e.message)

--- a/ftrace/parsers/binder_transaction_received.py
+++ b/ftrace/parsers/binder_transaction_received.py
@@ -1,0 +1,44 @@
+import re
+from ftrace.common import ParserError
+from .register import register_parser
+from .binder import parse_binder_cmd
+from collections import namedtuple
+
+TRACEPOINT = 'binder_transaction_received'
+
+__all__ = [TRACEPOINT]
+
+#binder_transaction_received: transaction=135934
+
+BinderTransactionReceivedBase = namedtuple(TRACEPOINT,
+    [
+    'transaction',
+    ]
+)
+
+class BinderTransactionReceived(BinderTransactionReceivedBase):
+    __slots__ = ()
+    def __new__(cls, transaction):
+
+            return super(cls, BinderTransactionReceived).__new__(
+                cls,
+                transaction=transaction
+            )
+
+binder_transaction_received_pattern = re.compile(
+    r"""
+    transaction=(\d+)
+    """,
+    re.X|re.M
+)
+
+@register_parser
+def binder_transaction_received(payload):
+    """Parser for `binder_transaction_received`"""
+    try:
+        match = re.match(binder_transaction_received_pattern, payload)
+        if match:
+            match_group_dict = match.groupdict()
+            return BinderTransactionReceived(int(match.group(1)))
+    except Exception as e:
+        raise ParserError(e.message)

--- a/ftrace/parsers/binder_transaction_ref_to_node.py
+++ b/ftrace/parsers/binder_transaction_ref_to_node.py
@@ -1,0 +1,61 @@
+import re
+from ftrace.common import ParserError
+from .register import register_parser
+from .binder import parse_binder_cmd
+from collections import namedtuple
+
+TRACEPOINT = 'binder_transaction_ref_to_node'
+
+__all__ = [TRACEPOINT]
+
+#binder_transaction_ref_to_node: transaction=135943 node=135186 src_ref=135187 src_desc=27 ==> dest_ptr=0x00000000941a4840
+
+BinderTransactionRefToNodeBase = namedtuple(TRACEPOINT,
+    [
+    'transaction',
+    'node',
+    'src_ref',
+    'src_desc',
+    'dest_ptr'
+    ]
+)
+
+class BinderTransactionRefToNode(BinderTransactionRefToNodeBase):
+    __slots__ = ()
+    def __new__(cls, transaction, node, src_ref, src_desc, dest_ptr):
+
+            return super(cls, BinderTransactionRefToNode).__new__(
+                cls,
+                transaction=transaction,
+                node=node,
+                src_ref=src_ref,
+                src_desc=src_desc,
+                dest_ptr=dest_ptr
+            )
+
+binder_transaction_ref_to_node_pattern = re.compile(
+    r"""
+    transaction=(\d+)\s+
+    node=(\d+)\s+
+    src_ref=(\d+)\s+
+    src_desc=(\d+)\s+
+    ==>\s+
+    dest_ptr=(0x[0-9a-f]+)
+    """,
+    re.X|re.M
+)
+
+@register_parser
+def binder_transaction_ref_to_node(payload):
+    """Parser for `binder_transaction_ref_to_node`"""
+    try:
+        match = re.match(binder_transaction_ref_to_node_pattern, payload)
+        if match:
+            match_group_dict = match.groupdict()
+            return BinderTransactionRefToNode(int(match.group(1)),
+                                              int(match.group(2)),
+                                              int(match.group(3)),
+                                              int(match.group(4)),
+                                              int(match.group(5), base=16))
+    except Exception as e:
+        raise ParserError(e.message)

--- a/ftrace/parsers/binder_transaction_ref_to_ref.py
+++ b/ftrace/parsers/binder_transaction_ref_to_ref.py
@@ -1,0 +1,65 @@
+import re
+from ftrace.common import ParserError
+from .register import register_parser
+from .binder import parse_binder_cmd
+from collections import namedtuple
+
+TRACEPOINT = 'binder_transaction_ref_to_ref'
+
+__all__ = [TRACEPOINT]
+
+#binder_transaction_ref_to_ref: transaction=136308 node=11089 src_ref=11090 src_desc=121 ==> dest_ref=136262 dest_desc=549
+
+BinderTransactionRefToRefBase = namedtuple(TRACEPOINT,
+    [
+    'transaction',
+    'node',
+    'src_ref',
+    'src_desc',
+    'dest_ref',
+    'dest_desc'
+    ]
+)
+
+class BinderTransactionRefToRef(BinderTransactionRefToRefBase):
+    __slots__ = ()
+    def __new__(cls, transaction, node, src_ref, src_desc, dest_ref, dest_desc):
+
+            return super(cls, BinderTransactionRefToRef).__new__(
+                cls,
+                transaction=transaction,
+                node=node,
+                src_ref=src_ref,
+                src_desc=src_desc,
+                dest_ref=dest_ref,
+                dest_desc=dest_desc
+            )
+
+binder_transaction_ref_to_ref_pattern = re.compile(
+    r"""
+    transaction=(\d+)\s+
+    node=(\d+)\s+
+    src_ref=(\d+)\s+
+    src_desc=(\d+)\s+
+    ==>\s+
+    dest_ref=(\d+)\s+
+    dest_desc=(\d+)
+    """,
+    re.X|re.M
+)
+
+@register_parser
+def binder_transaction_ref_to_ref(payload):
+    """Parser for `binder_transaction_ref_to_ref`"""
+    try:
+        match = re.match(binder_transaction_ref_to_ref_pattern, payload)
+        if match:
+            match_group_dict = match.groupdict()
+            return BinderTransactionRefToRef(int(match.group(1)),
+                                             int(match.group(2)),
+                                             int(match.group(3)),
+                                             int(match.group(4)),
+                                             int(match.group(5)),
+                                             int(match.group(6)))
+    except Exception as e:
+        raise ParserError(e.message)

--- a/ftrace/parsers/binder_unlock.py
+++ b/ftrace/parsers/binder_unlock.py
@@ -38,6 +38,6 @@ def binder_unlock(payload):
         if match:
             match_group_dict = match.groupdict()
             return BinderUnlock(match.group(1))
-    except Exception, e:
+    except Exception as e:
         raise ParserError(e.message)
 

--- a/ftrace/parsers/binder_unlock.py
+++ b/ftrace/parsers/binder_unlock.py
@@ -1,0 +1,43 @@
+import re
+from ftrace.common import ParserError
+from .register import register_parser
+from collections import namedtuple
+
+TRACEPOINT = 'binder_unlock'
+
+__all__ = [TRACEPOINT]
+
+#binder_unlock: tag=binder_ioctl
+
+BinderUnlockBase = namedtuple(TRACEPOINT,
+    [
+    'tag'
+    ]
+)
+
+class BinderUnlock(BinderUnlockBase):
+    __slots__ = ()
+    def __new__(cls, tag):
+            return super(cls, BinderUnlock).__new__(
+                cls,
+                tag=tag
+            )
+
+binder_unlock_pattern = re.compile(
+    r"""
+    tag=([^\s]+)
+    """,
+    re.X|re.M
+)
+
+@register_parser
+def binder_unlock(payload):
+    """Parser for `binder_unlock`"""
+    try:
+        match = re.match(binder_unlock_pattern, payload)
+        if match:
+            match_group_dict = match.groupdict()
+            return BinderUnlock(match.group(1))
+    except Exception, e:
+        raise ParserError(e.message)
+

--- a/ftrace/parsers/binder_update_page_range.py
+++ b/ftrace/parsers/binder_update_page_range.py
@@ -1,0 +1,53 @@
+import re
+from ftrace.common import ParserError
+from .register import register_parser
+from .binder import parse_binder_cmd
+from collections import namedtuple
+
+TRACEPOINT = 'binder_update_page_range'
+
+__all__ = [TRACEPOINT]
+
+#binder_update_page_range: proc=3624 allocate=1 offset=4096 size=8192
+
+BinderUpdatePageRangeBase = namedtuple(TRACEPOINT,
+    [
+    'proc',
+    'allocate',
+    'offset',
+    'size'
+    ]
+)
+
+class BinderUpdatePageRange(BinderUpdatePageRangeBase):
+    __slots__ = ()
+    def __new__(cls, proc, allocate, offset, size):
+
+            return super(cls, BinderUpdatePageRange).__new__(
+                cls,
+                proc=proc,
+                allocate=allocate,
+                offset=offset,
+                size=size
+            )
+
+binder_update_page_range_pattern = re.compile(
+    r"""
+    proc=(\d+)\s+
+    allocate=(\d+)\s+
+    offset=(\d+)\s+
+    size=(\d+)
+    """,
+    re.X|re.M
+)
+
+@register_parser
+def binder_update_page_range(payload):
+    """Parser for `binder_update_page_range`"""
+    try:
+        match = re.match(binder_update_page_range_pattern, payload)
+        if match:
+            match_group_dict = match.groupdict()
+            return BinderUpdatePageRange(int(match.group(1)), int(match.group(2)), int(match.group(3)), int(match.group(4)))
+    except Exception as e:
+        raise ParserError(e.message)

--- a/ftrace/parsers/binder_wait_for_work.py
+++ b/ftrace/parsers/binder_wait_for_work.py
@@ -1,0 +1,50 @@
+import re
+from ftrace.common import ParserError
+from .register import register_parser
+from .binder import parse_binder_cmd
+from collections import namedtuple
+
+TRACEPOINT = 'binder_wait_for_work'
+
+__all__ = [TRACEPOINT]
+
+#binder_wait_for_work: proc_work=0 transaction_stack=1 thread_todo=0
+
+BinderWaitForWorkBase = namedtuple(TRACEPOINT,
+    [
+    'proc_work',
+    'transaction_stack',
+    'thread_todo'
+    ]
+)
+
+class BinderWaitForWork(BinderWaitForWorkBase):
+    __slots__ = ()
+    def __new__(cls, proc_work, transaction_stack, thread_todo):
+
+            return super(cls, BinderWaitForWork).__new__(
+                cls,
+                proc_work=proc_work,
+                transaction_stack=transaction_stack,
+                thread_todo=thread_todo
+            )
+
+binder_ioctl_pattern = re.compile(
+    r"""
+    proc_work=(\d+)\s+
+    transaction_stack=(\d+)\s+
+    thread_todo=(\d+)
+    """,
+    re.X|re.M
+)
+
+@register_parser
+def binder_wait_for_work(payload):
+    """Parser for `binder_wait_for_work`"""
+    try:
+        match = re.match(binder_ioctl_pattern, payload)
+        if match:
+            match_group_dict = match.groupdict()
+            return BinderWaitForWork(int(match.group(1)), int(match.group(2)), int(match.group(3)))
+    except Exception as e:
+        raise ParserError(e.message)

--- a/ftrace/parsers/binder_wait_for_work.py
+++ b/ftrace/parsers/binder_wait_for_work.py
@@ -29,7 +29,7 @@ class BinderWaitForWork(BinderWaitForWorkBase):
                 thread_todo=thread_todo
             )
 
-binder_ioctl_pattern = re.compile(
+binder_wait_for_work_pattern = re.compile(
     r"""
     proc_work=(\d+)\s+
     transaction_stack=(\d+)\s+
@@ -42,7 +42,7 @@ binder_ioctl_pattern = re.compile(
 def binder_wait_for_work(payload):
     """Parser for `binder_wait_for_work`"""
     try:
-        match = re.match(binder_ioctl_pattern, payload)
+        match = re.match(binder_wait_for_work_pattern, payload)
         if match:
             match_group_dict = match.groupdict()
             return BinderWaitForWork(int(match.group(1)), int(match.group(2)), int(match.group(3)))

--- a/ftrace/parsers/binder_write_done.py
+++ b/ftrace/parsers/binder_write_done.py
@@ -1,0 +1,44 @@
+import re
+from ftrace.common import ParserError
+from .register import register_parser
+from .binder import parse_binder_cmd
+from collections import namedtuple
+
+TRACEPOINT = 'binder_write_done'
+
+__all__ = [TRACEPOINT]
+
+#binder_write_done: ret=0
+
+BinderWriteDoneBase = namedtuple(TRACEPOINT,
+    [
+    'ret'
+    ]
+)
+
+class BinderWriteDone(BinderWriteDoneBase):
+    __slots__ = ()
+    def __new__(cls, ret):
+
+            return super(cls, BinderWriteDone).__new__(
+                cls,
+                ret=ret
+            )
+
+binder_write_done_pattern = re.compile(
+    r"""
+    ret=(\d+)
+    """,
+    re.X|re.M
+)
+
+@register_parser
+def binder_write_done(payload):
+    """Parser for `binder_write_done`"""
+    try:
+        match = re.match(binder_write_done_pattern, payload)
+        if match:
+            match_group_dict = match.groupdict()
+            return BinderWriteDone(int(match.group(1)))
+    except Exception as e:
+        raise ParserError(e.message)


### PR DESCRIPTION
This patch set enables parsing of Binder (i.e. low-level IPC) traces for Android. To get the respective traces, they need to be compiled into the kernel and enabled in /sys:
```sh
# echo > /sys/kernel/debug/tracing/set_event
# echo 1 > /sys/kernel/debug/tracing/events/binder/enable
# echo 1 > /sys/kernel/debug/tracing/events/binder/tracing_on
```
When done with the to-be-traced activity, disable binder trace and read result:
```sh
# echo 0 > /sys/kernel/debug/tracing/events/binder/tracing_on
# cat /sys/kernel/debug/tracing/trace
```